### PR TITLE
Generic Database Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 !/tmp/.keep
 
 .byebug_history
+
+# Database Settings
+/config/database.yml

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,0 +1,28 @@
+# SQLite version 3.x
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  # username: usuario_do_seu_banco
+  # password: senha_do_seu_banco
+  timeout: 5000
+
+development:
+  <<: *default
+  database: pub
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: pub
+
+production:
+  <<: *default
+  database: pub


### PR DESCRIPTION
Database settings must be added to the repository in a generic way, so that any contributor can configure their database in the way they think best.

 - Created database.yml.example (generic);
 - Added database.yml to .gitignore.